### PR TITLE
修改接口描述文件

### DIFF
--- a/b.基础特性/b.编写接口.mdx
+++ b/b.基础特性/b.编写接口.mdx
@@ -24,7 +24,7 @@
       "method": "GET",
       "guard": "-",
       "process": "models.pet.Paginate",
-      "query": [":query-param", "$query.page", "$quey.pagesize"],
+      "in": [":query-param", "$query.page", "$query.pagesize"],
       "out": {
         "status": 200,
         "type": "application/json"


### PR DESCRIPTION
在本地测试的时候，发现示例接口的描述文件无法直接使用，仔细阅读文档后，对接口描述做了修改。